### PR TITLE
Set the Subject Key Identifier when generating certificates

### DIFF
--- a/types/certificate_generator_test.go
+++ b/types/certificate_generator_test.go
@@ -138,6 +138,11 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						Expect(certificate.ExtKeyUsage).To(BeEmpty())
 					})
 
+					It("sets SubjectKeyId", func() {
+						Expect(certificate.SubjectKeyId).ToNot(BeNil())
+						Expect(certificate.SubjectKeyId).To(HaveLen(20))
+					})
+
 					It("sets Issuer, Country & Org", func() {
 						Expect(certificate.Issuer.Country).To(Equal([]string{"USA"}))
 						Expect(certificate.Issuer.Organization).To(Equal([]string{"Cloud Foundry"}))
@@ -167,6 +172,11 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 					It("sets KeyUsage and ExtKeyUsage", func() {
 						Expect(certificate.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
 						Expect(certificate.ExtKeyUsage).To(BeEmpty())
+					})
+
+					It("sets SubjectKeyId", func() {
+						Expect(certificate.SubjectKeyId).ToNot(BeNil())
+						Expect(certificate.SubjectKeyId).To(HaveLen(20))
 					})
 
 					It("sets Issuer Country & Org", func() {
@@ -230,6 +240,14 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						certificate, _ := parseCertString(certResp.Certificate)
 
 						Expect(certificate.KeyUsage).To(Equal(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature))
+					})
+
+					It("should have a SubjectKeyId", func() {
+						certResp := getCertResp(generator, params)
+						certificate, _ := parseCertString(certResp.Certificate)
+
+						Expect(certificate.SubjectKeyId).ToNot(BeNil())
+						Expect(certificate.SubjectKeyId).To(HaveLen(20))
 					})
 
 					It("sets common name and alternative name as passed in", func() {


### PR DESCRIPTION
The identifier is the 160-bit SHA-1 hash of the public key (see [1]).

This library is used by the BOSH cli and the BOSH cli can be used to generate
certificates into a variable store - based on the manifest variable definitons.
There is a known issue if you try to rotate the CA certificates outlined in [2].

The root of the problem is that when OpenSSL is configured to trust multiple
CAs, and two of them have the same subject name, OpenSSL will only verify
certificates against the first one (see [3] in OpenSSL code).

One solution for the CA certificate rotation problem is to set the Subject Key
Identifiers so OpenSSL will be able to handle multiple certificates with the
same subject name.

The generation method is based on certstrap's solution. [4]

[1] https://tools.ietf.org/html/rfc5280#section-4.2.1.2
[2] https://docs.google.com/document/d/1vKxziTEvIgKHubukoyAGaJzGqrMBjun7JffbunlLBPg/edit
[3] https://github.com/openssl/openssl/blob/49f6cb9/crypto/x509/x509_lu.c#L613-L617
[4] https://github.com/square/certstrap/blob/b6aef50/pkix/key.go#L150