### PR TITLE
Updated link in README.md for bosh-notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ## Config Server
 
-* CI: <https://main.bosh-ci.cf-app.com/teams/main/pipelines/config-server>
-* [API Docs](docs/api.md)
-
+- CI: <https://main.bosh-ci.cf-app.com/teams/main/pipelines/config-server>
+- [API Docs](docs/api.md)
 
 See [config-server-release](https://github.com/cloudfoundry/config-server-release) for the release repo for config-server
-See [bosh-notes](https://github.com/cloudfoundry/bosh-notes/blob/master/finished/config-server.md) for more information
+See [bosh-notes](https://github.com/cloudfoundry/bosh-notes/blob/master/proposals/config-server.md) for more information


### PR DESCRIPTION
I've update the broken URL in the `README.md` file to the correct one.
Fixes #10 