### PR TITLE
Use a 2-letters ISO 3166 country code, as required by RFC 2459

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,36 @@
-## Config Server
+# Config Server
 
 - CI: <https://main.bosh-ci.cf-app.com/teams/main/pipelines/config-server>
 - [API Docs](docs/api.md)
 
 See [config-server-release](https://github.com/cloudfoundry/config-server-release) for the release repo for config-server
 See [bosh-notes](https://github.com/cloudfoundry/bosh-notes/blob/master/proposals/config-server.md) for more information
+
+## Contributing
+
+Before submitting PRs, you should make sure that tests are passing properly.
+
+### Unit tests
+
+Before running the unit test on your local machine, you should install
+`golangci-lint` following its documentation, see
+<https://github.com/golangci/golangci-lint>. (Indeed, the way the
+[lint](bin/lint) script installs `golangci-lint` is not suitable for running
+on a local machine.)
+
+Then run the unit tests using the dedicated script.
+
+```bash
+bin/test-unit
+```
+
+### Integration tests
+
+There a re 3 distinct flavors of integration tests. Run the relevant one, or
+all, depending on the changes you've done.
+
+```bash
+bin/test-unit memory     # <- uses an in-memory database
+bin/test-unit mysql      # <- uses a MySQL database
+bin/test-unit postgresql # <- uses a PostgreSQL database
+```

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Supported HTTP Methods", func() {
 			Expect(cert.IsCA).To(BeFalse())
 
 			Expect(cert.Issuer.Organization).To(ContainElement("Cloud Foundry"))
-			Expect(cert.Issuer.Country).To(ContainElement("USA"))
+			Expect(cert.Issuer.Country).To(ContainElement("US"))
 			Expect(cert.Issuer.CommonName).To(Equal("some-root-certificate-ca-cn1"))
 		})
 
@@ -344,7 +344,7 @@ var _ = Describe("Supported HTTP Methods", func() {
 			Expect(cert.Subject.CommonName).To(Equal("some-root-certificate-ca-cn1"))
 
 			Expect(cert.Issuer.Organization).To(ContainElement("Cloud Foundry"))
-			Expect(cert.Issuer.Country).To(ContainElement("USA"))
+			Expect(cert.Issuer.Country).To(ContainElement("US"))
 		})
 
 		It("generates a new id and intermediate ca certificate for a new name", func() {
@@ -365,7 +365,7 @@ var _ = Describe("Supported HTTP Methods", func() {
 			Expect(cert.Subject.CommonName).To(Equal("some-intermediate-certificate-ca-cn1"))
 
 			Expect(cert.Issuer.Organization).To(ContainElement("Cloud Foundry"))
-			Expect(cert.Issuer.Country).To(ContainElement("USA"))
+			Expect(cert.Issuer.Country).To(ContainElement("US"))
 			Expect(cert.Issuer.CommonName).To(Equal("some-root-certificate-ca-cn1"))
 		})
 

--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -187,7 +187,7 @@ func generateCertTemplate(cParams certParams) (x509.Certificate, error) {
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			Country:      []string{"USA"},
+			Country:      []string{"US"},
 			Organization: organizations,
 			CommonName:   cParams.CommonName,
 		},

--- a/types/certificate_generator_test.go
+++ b/types/certificate_generator_test.go
@@ -140,7 +140,7 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 					})
 
 					It("sets Issuer, Country & default Org", func() {
-						Expect(certificate.Issuer.Country).To(Equal([]string{"USA"}))
+						Expect(certificate.Issuer.Country).To(Equal([]string{"US"}))
 						Expect(certificate.Issuer.Organization).To(Equal([]string{"Cloud Foundry"}))
 						Expect(certificate.Issuer.CommonName).To(Equal(""))
 					})
@@ -161,7 +161,7 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						})
 
 						It("sets Issuer, Country & default Org", func() {
-							Expect(certificate.Issuer.Country).To(Equal([]string{"USA"}))
+							Expect(certificate.Issuer.Country).To(Equal([]string{"US"}))
 							Expect(certificate.Issuer.Organization).To(Equal([]string{"Hi Five BOSH"}))
 							Expect(certificate.Issuer.CommonName).To(Equal(""))
 						})


### PR DESCRIPTION
Hi there,

In order to fix cloudfoundry/bosh#2473 and cloudfoundry/bosh-cli#632, here is a small patch so that the generated certificates have a valid 2-letters ISO 3166 country code, as required by RFC 2459 [in Appendix A](https://www.ietf.org/rfc/rfc2459.html#appendix-A).

I’ve also written some short instructions for running unit and integration tests, based on my experience doing it today. About `golangci-lint`, I also wonder if this installation code is still relevant :
https://github.com/cloudfoundry/config-server/blob/master/bin/lint#L6-L11
Indeed, this way of doing is no more recommended, see <https://golangci-lint.run/usage/install/#install-from-source>, and I’ve not been able to run `golangci-lint` this way.

Cheers