### PR TITLE
Make RSA key size configurable via key_length parameter

### DIFF
--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -14,6 +14,9 @@ import (
 
 	"github.com/cloudfoundry/bosh-utils/errors"
 )
+const DefaultKeyLength = 3072
+
+var validKeyLengths = []int{2048, 3072, 4096}
 
 type CertificateGenerator struct {
 	loader CertsLoader
@@ -73,7 +76,7 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 
 	keyLength := cParams.KeyLength
 	if keyLength == 0 {
-		keyLength = 3072
+		keyLength = DefaultKeyLength
 	}
 
 	// Validate that key length is one of the standard RSA key sizes
@@ -86,7 +89,8 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 		}
 	}
 	if !isValid {
-		return certResponse, errors.Errorf("Invalid key_length: %d. Must be one of: 2048, 3072, or 4096", keyLength)
+		return certResponse, errors.Errorf("Invalid key_length: %d.  Must be one of: %v", 
+			keyLength, validKeyLengths)
 	}
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, keyLength)

--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cloudfoundry/bosh-utils/errors"
 )
+
 const DefaultKeyLength = 3072
 
 var validKeyLengths = []int{2048, 3072, 4096}
@@ -88,7 +89,7 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 		}
 	}
 	if !isValid {
-		return certResponse, errors.Errorf("Invalid key_length: %d.  Must be one of: %v", 
+		return certResponse, errors.Errorf("Invalid key_length: %d.  Must be one of: %v",
 			keyLength, validKeyLengths)
 	}
 

--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -76,6 +76,19 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 		keyLength = 3072
 	}
 
+	// Validate that key length is one of the standard RSA key sizes
+	validKeyLengths := []int{2048, 3072, 4096}
+	isValid := false
+	for _, length := range validKeyLengths {
+		if keyLength == length {
+			isValid = true
+			break
+		}
+	}
+	if !isValid {
+		return certResponse, errors.Errorf("Invalid key_length: %d. Must be one of: 2048, 3072, or 4096", keyLength)
+	}
+
 	privateKey, err := rsa.GenerateKey(rand.Reader, keyLength)
 	if err != nil {
 		return certResponse, errors.WrapError(err, "Generating Key")

--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -80,7 +80,6 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 	}
 
 	// Validate that key length is one of the standard RSA key sizes
-	validKeyLengths := []int{2048, 3072, 4096}
 	isValid := false
 	for _, length := range validKeyLengths {
 		if keyLength == length {

--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -34,6 +34,7 @@ type certParams struct {
 	CAName           string   `yaml:"ca"`
 	ExtKeyUsage      []string `yaml:"extended_key_usage"`
 	Duration         int64    `yaml:"duration"`
+	KeyLength        int      `yaml:"key_length"`
 }
 
 var supportedCertParameters = []string{
@@ -44,6 +45,7 @@ var supportedCertParameters = []string{
 	"ca",
 	"extended_key_usage",
 	"duration",
+	"key_length",
 }
 
 func NewCertificateGenerator(loader CertsLoader) CertificateGenerator {
@@ -69,7 +71,12 @@ func (cfg CertificateGenerator) bigIntHash(n *big.Int) []byte {
 func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertResponse, error) {
 	var certResponse CertResponse
 
-	privateKey, err := rsa.GenerateKey(rand.Reader, 3072)
+	keyLength := cParams.KeyLength
+	if keyLength == 0 {
+		keyLength = 3072
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, keyLength)
 	if err != nil {
 		return certResponse, errors.WrapError(err, "Generating Key")
 	}

--- a/types/certificate_generator_test.go
+++ b/types/certificate_generator_test.go
@@ -343,8 +343,8 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						Expect(certResp.PrivateKey).NotTo(BeEmpty())
 
 						block, _ := pem.Decode([]byte(certResp.PrivateKey))
-						key, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
-
+						key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+						Expect(err).To(BeNil())
 						Expect(key.PublicKey.N.BitLen()).To(Equal(2048))
 					})
 

--- a/types/certificate_generator_test.go
+++ b/types/certificate_generator_test.go
@@ -325,7 +325,7 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						Expect(certificate.IsCA).To(BeFalse())
 					})
 
-					It("generates a 3072-bit private key", func() {
+					It("generates a 3072-bit private key by default", func() {
 						certResp := getCertResp(generator, params)
 
 						Expect(certResp.PrivateKey).NotTo(BeEmpty())
@@ -334,6 +334,18 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						key, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
 
 						Expect(key.PublicKey.N.BitLen()).To(Equal(3072))
+					})
+
+					It("generates a private key with custom key_length when specified", func() {
+						params["key_length"] = 2048
+						certResp := getCertResp(generator, params)
+
+						Expect(certResp.PrivateKey).NotTo(BeEmpty())
+
+						block, _ := pem.Decode([]byte(certResp.PrivateKey))
+						key, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
+
+						Expect(key.PublicKey.N.BitLen()).To(Equal(2048))
 					})
 
 					It("should have the public keys of the private key and certificate match", func() {

--- a/types/certificate_generator_test.go
+++ b/types/certificate_generator_test.go
@@ -348,6 +348,15 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						Expect(key.PublicKey.N.BitLen()).To(Equal(2048))
 					})
 
+					It("returns an error when key_length is not a standard size", func() {
+						params["key_length"] = 1234
+						_, err := generator.Generate(params)
+
+						Expect(err).ToNot(BeNil())
+						Expect(err.Error()).To(ContainSubstring("Invalid key_length: 1234"))
+						Expect(err.Error()).To(ContainSubstring("Must be one of: 2048, 3072, or 4096"))
+					})
+
 					It("should have the public keys of the private key and certificate match", func() {
 						certResp := getCertResp(generator, params)
 						certificate, _ := parseCertString(certResp.Certificate)


### PR DESCRIPTION
## Add configurable key_length parameter for certificate generation

### Summary
This PR adds support for configurable RSA key lengths in certificate generation. Previously, the key length was hardcoded to 3072 bits. Now it is possible to specify a custom `key_length` parameter when generating certificates.

### Changes
- Added `key_length` to the list of supported certificate parameters
- Modified generation logic to use 3072-bit by default if `key_length` is not specified
