### PR TITLE
Replace SHA-1 with SHA-256 for X.509 SubjectKeyIdentifier computation

### DIFF
--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -3,14 +3,13 @@ package types
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
 	"net"
 	"time"
-
-	"crypto/sha1"
 
 	"github.com/cloudfoundry/bosh-utils/errors"
 )
@@ -60,10 +59,15 @@ func (cfg CertificateGenerator) Generate(parameters interface{}) (interface{}, e
 	return cfg.generateCertificate(params)
 }
 
-func (cfg CertificateGenerator) bigIntHash(n *big.Int) []byte {
-	h := sha1.New()
-	h.Write(n.Bytes())
-	return h.Sum(nil)
+// computeSubjectKeyId derives the SubjectKeyIdentifier per RFC 7093 Method 4:
+// SHA-256 of the full DER-encoded SubjectPublicKeyInfo structure.
+func computeSubjectKeyId(pub *rsa.PublicKey) ([]byte, error) {
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.Sum256(pubDER)
+	return hash[:], nil
 }
 
 func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertResponse, error) {
@@ -94,7 +98,11 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 		}
 	}
 
-	certTemplate.SubjectKeyId = cfg.bigIntHash(privateKey.N)
+	subjectKeyId, err := computeSubjectKeyId(&privateKey.PublicKey)
+	if err != nil {
+		return certResponse, errors.WrapError(err, "Computing SubjectKeyId")
+	}
+	certTemplate.SubjectKeyId = subjectKeyId
 
 	if cParams.IsCA {
 		certTemplate.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign


### PR DESCRIPTION
## Summary

Fixes #39

- Removes the deprecated `crypto/sha1` import and `bigIntHash(*big.Int)` method, which hashed only the RSA key modulus (`privateKey.N`) using SHA-1.
- Introduces `computeSubjectKeyId(*rsa.PublicKey)` implementing **RFC 7093 Method 4**: SHA-256 of the full DER-encoded `SubjectPublicKeyInfo` structure via `x509.MarshalPKIXPublicKey`.
- All 52 existing unit tests pass without modification.

## Why this matters

SHA-1 is deprecated by **NIST SP 800-131A Rev 2** and is explicitly **disallowed under FIPS 140-2/3** compliance requirements. Any deployment of config-server in a FIPS-enforcing environment (e.g. US Government, regulated industries) will fail cert generation at runtime with the current implementation.

## What changed and why

| | Before | After |
|---|---|---|
| **Hash algorithm** | SHA-1 | SHA-256 |
| **Hash input** | `privateKey.N` (modulus only) | Full `SubjectPublicKeyInfo` DER |
| **Output size** | 20 bytes | 32 bytes |
| **RFC alignment** | Non-standard (missing exponent + algorithm OID) | RFC 7093 Method 4 |

The previous implementation was doubly incorrect: beyond using SHA-1, it only hashed the RSA modulus `N`, omitting the public exponent `E` and the algorithm identifier. Two keys with the same modulus but different exponents could produce the same SubjectKeyId. The new implementation hashes the complete `SubjectPublicKeyInfo` as defined in RFC 5280 / RFC 7093.

## Impact on existing deployments

- **Existing certificates** in the database are not affected — only newly generated certs are changed.
- **Chain validation** is unaffected — TLS chain verification uses cryptographic signatures, not SKI/AKI values.
- **Mixed environments** (new certs signed by old SHA-1-SKI CAs): the AKI on the new cert is copied directly from the signing CA's `SubjectKeyId` field, so it correctly reflects the CA's original 20-byte value. RFC 5280 does not require AKI and SKI to be the same size.

## Test plan

- [x] `go build ./types/...` compiles cleanly
- [x] `go test ./types/...` 52/52 specs pass
- [x] Verified `SubjectKeyId` is non-nil on generated certs
- [x] Verified self-signed CA `SubjectKeyId == AuthorityKeyId`
- [x] Verified leaf cert `AuthorityKeyId == signingCA.SubjectKeyId`

## References

- [NIST SP 800-131A Rev 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final) - SHA-1 deprecation
- [RFC 5280 Section 4.2.1.2](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.2) - SubjectKeyIdentifier extension
- [RFC 7093](https://www.rfc-editor.org/rfc/rfc7093) - Additional Methods for Generating Key Identifiers

